### PR TITLE
存在しないメールアドレスか、パスワードが間違っている場合にエラーになるバグの解消

### DIFF
--- a/nova/app/controllers/sessions_controller.rb
+++ b/nova/app/controllers/sessions_controller.rb
@@ -12,7 +12,7 @@ class SessionsController < ApplicationController
       self.current_user = @user
       redirect_to dashboard_path
     else
-      render :new, status: :bad_request
+      redirect_to login_path, alert: 'ユーザーが存在しないかパスワードが間違っています'
     end
   end
 

--- a/nova/app/views/layouts/_flash.html.slim
+++ b/nova/app/views/layouts/_flash.html.slim
@@ -1,0 +1,9 @@
+- if flash.now[:notice]
+  .message.is-info
+    .message-body
+      = flash.now[:notice]
+
+- if flash.now[:alert]
+  .message.is-danger
+    .message-body
+      = flash.now[:alert]

--- a/nova/app/views/layouts/application.html.slim
+++ b/nova/app/views/layouts/application.html.slim
@@ -38,5 +38,6 @@ html(lang="#{I18n.locale}" class="#{html_classes.join(' ')}")
           .columns
             .column.is-8.is-offset-2
 
+              = render 'layouts/flash'
               = yield
 


### PR DESCRIPTION
`sessioncontroller#create`において,`@user`が`nil`の状態で`render 'new'`しようとしているためエラーになっていた。
https://github.com/4geru/2018-newbies/blob/master/nova/app/views/users/new.html.slim#L1

本来はrenderで遷移させる方が良いのだが、一旦動くようにするために、`redirect_to`で`session#new`に遷移するように変更を加えた。
また、flashmessageをviewで表示できていなかったので、表示させるように変更を加えた。

