### PR TITLE
Milestone/history2master

### DIFF
--- a/nova/Gemfile
+++ b/nova/Gemfile
@@ -28,6 +28,7 @@ gem 'aws-sdk-codedeploy'
 
 # Use ActiveModel has_secure_password
 gem 'bcrypt', '~> 3.1.7'
+gem 'kaminari'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/nova/Gemfile.lock
+++ b/nova/Gemfile.lock
@@ -111,6 +111,18 @@ GEM
       multi_json (>= 1.2)
     jmespath (1.4.0)
     json (2.1.0)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -305,6 +317,7 @@ DEPENDENCIES
   factory_bot_rails
   ffaker
   jbuilder (~> 2.5)
+  kaminari
   listen (>= 3.0.5, < 3.2)
   locale_kit
   meta-tags

--- a/nova/app/assets/javascripts/dashboard.js
+++ b/nova/app/assets/javascripts/dashboard.js
@@ -56,6 +56,7 @@ document.addEventListener('DOMContentLoaded', function() {
   var dashboard = new Vue({
     el: '#dashboard',
     data: {
+      page: 1,
       currentTab: 'remits',
       amount: 0,
       charges: [],
@@ -75,6 +76,7 @@ document.addEventListener('DOMContentLoaded', function() {
     },
     beforeMount: function() {
       var self = this;
+      self.page = 1;
       api.get('/api/user').then(function(json) {
         self.user = json;
       });
@@ -84,13 +86,13 @@ document.addEventListener('DOMContentLoaded', function() {
         self.charges = json.charges;
       });
 
-      api.get('/api/remit_requests', { status: 'outstanding' }).
+      api.get('/api/remit_requests', { status: 'outstanding', page: self.page }).
         then(function(json) {
           self.recvRemits = json;
         });
 
       setInterval(function() {
-        api.get('/api/remit_requests', { status: 'outstanding' }).
+        api.get('/api/remit_requests', { status: 'outstanding', page: self.page }).
           then(function(json) {
             self.recvRemits = json;
           });
@@ -190,6 +192,28 @@ document.addEventListener('DOMContentLoaded', function() {
             self.user = json;
           });
       },
+      jumpRemixPage: function(page, event) {
+        var self = this;
+
+        self.updateRemixPage(page)
+      },
+      changeRemixPage: function(diff, event) {
+        var self = this;
+
+        self.updateRemixPage(self.page + diff)
+      },
+      updateRemixPage: function(next) {
+        var self = this;
+        console.log('called')
+        api.get('/api/remit_requests', { status: 'outstanding', page: next }).
+        then(function(json) {
+          self.recvRemits = json;
+          document.getElementsByClassName('pagination-link')[self.page-1].classList.remove('is-current')
+          document.getElementsByClassName('pagination-link')[next-1].classList.add('is-current')
+          self.page = next
+        });
+
+      }
     }
   });
 });

--- a/nova/app/assets/javascripts/dashboard.js
+++ b/nova/app/assets/javascripts/dashboard.js
@@ -62,6 +62,7 @@ document.addEventListener('DOMContentLoaded', function() {
       charges: [],
       recvRemits: [],
       sentRemits: [],
+      maxPage: 1,
       hasCreditCard: hasCreditCard,
       isActiveNewRemitForm: false,
       target: "",
@@ -88,13 +89,15 @@ document.addEventListener('DOMContentLoaded', function() {
 
       api.get('/api/remit_requests', { status: 'outstanding', page: self.page }).
         then(function(json) {
-          self.recvRemits = json;
+          self.maxPage = json.max_pages
+          self.recvRemits = json.remit_requests;
+          document.getElementsByClassName('pagination-link')[0].classList.add('is-current')
         });
 
       setInterval(function() {
         api.get('/api/remit_requests', { status: 'outstanding', page: self.page }).
           then(function(json) {
-            self.recvRemits = json;
+          self.recvRemits = json.remit_requests;
           });
       }, 5000);
     },
@@ -207,7 +210,7 @@ document.addEventListener('DOMContentLoaded', function() {
         console.log('called')
         api.get('/api/remit_requests', { status: 'outstanding', page: next }).
         then(function(json) {
-          self.recvRemits = json;
+          self.recvRemits = json.remit_requests;
           document.getElementsByClassName('pagination-link')[self.page-1].classList.remove('is-current')
           document.getElementsByClassName('pagination-link')[next-1].classList.add('is-current')
           self.page = next

--- a/nova/app/assets/javascripts/dashboard.js
+++ b/nova/app/assets/javascripts/dashboard.js
@@ -97,7 +97,7 @@ document.addEventListener('DOMContentLoaded', function() {
       setInterval(function() {
         api.get('/api/remit_requests', { status: 'outstanding', page: self.page }).
           then(function(json) {
-          self.recvRemits = json.remit_requests;
+            self.recvRemits = json.remit_requests;
           });
       }, 5000);
     },
@@ -200,14 +200,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
         self.updateRemixPage(page)
       },
-      changeRemixPage: function(diff, event) {
-        var self = this;
-
-        self.updateRemixPage(self.page + diff)
-      },
       updateRemixPage: function(next) {
         var self = this;
-        console.log('called')
+
         api.get('/api/remit_requests', { status: 'outstanding', page: next }).
         then(function(json) {
           self.recvRemits = json.remit_requests;

--- a/nova/app/controllers/api/remit_requests_controller.rb
+++ b/nova/app/controllers/api/remit_requests_controller.rb
@@ -3,8 +3,9 @@
 class Api::RemitRequestsController < Api::ApplicationController
   def index
     @remit_requests = current_user.received_remit_requests.page(params[:page])
-    pages = current_user.received_remit_requests.count / 10 + 
-      ( current_user.received_remit_requests.count % 10 ? 1 : 0)
+    page_limit = @remit_requests.counts
+    pages = current_user.received_remit_requests.count / page_limit + 
+      ( current_user.received_remit_requests.count % page_limit ? 1 : 0)
     render json:{max_pages: pages, remit_requests: @remit_requests.as_json(include: :user).to_a}
   end
 

--- a/nova/app/controllers/api/remit_requests_controller.rb
+++ b/nova/app/controllers/api/remit_requests_controller.rb
@@ -2,9 +2,9 @@
 
 class Api::RemitRequestsController < Api::ApplicationController
   def index
-    @remit_requests = current_user.received_remit_requests.send(params[:status] || 'outstanding').order(id: :desc).limit(50)
-
-    render json: @remit_requests.as_json(include: :user)
+    @remit_requests = current_user.received_remit_requests.page(params[:page])
+    @pages = current_user.received_remit_requests
+    render json: @remit_requests.as_json(include: :user)#.as_join(page: @pages)
   end
 
   def create

--- a/nova/app/controllers/api/remit_requests_controller.rb
+++ b/nova/app/controllers/api/remit_requests_controller.rb
@@ -3,8 +3,9 @@
 class Api::RemitRequestsController < Api::ApplicationController
   def index
     @remit_requests = current_user.received_remit_requests.page(params[:page])
-    @pages = current_user.received_remit_requests
-    render json: @remit_requests.as_json(include: :user)#.as_join(page: @pages)
+    pages = current_user.received_remit_requests.count / 10 + 
+      ( current_user.received_remit_requests.count % 10 ? 1 : 0)
+    render json:{max_pages: pages, remit_requests: @remit_requests.as_json(include: :user).to_a}
   end
 
   def create

--- a/nova/app/models/remit_request.rb
+++ b/nova/app/models/remit_request.rb
@@ -5,6 +5,7 @@ class RemitRequest < ApplicationRecord
   belongs_to :target, class_name: 'User'
 
   validates :amount, numericality: { greater_then: 0 }
+  paginates_per 10
 
   scope :outstanding, ->(at = Time.current) { not_accepted(at).not_rejected(at).not_canceled(at) }
   scope :accepted, ->(at = Time.current) { where(RemitRequest.arel_table[:accepted_at].lteq(at)) }

--- a/nova/app/views/dashboard/show.html.slim
+++ b/nova/app/views/dashboard/show.html.slim
@@ -57,7 +57,6 @@
       .section
         button.button.is-info.is-fullwidth(@click="isActiveNewRemitForm = true")
           | Make New Remit Request
-
       table.table.is-fullwidth
         thead
           tr
@@ -72,6 +71,16 @@
               .buttons.is-right
                 button.button.is-small(:disabled="amount < remit.amount" @click='accept(remit.id, $event)') Accept
                 button.button.is-small(@click='reject(remit.id, $event)') Reject
+      nav.pagination aria-label="pagination" role="navigation"
+        a.pagination-previous @click='changeRemixPage(-1, $event)' Previous
+        a.pagination-next @click='changeRemixPage(1, $event)' Next page
+        ul.pagination-list
+          li
+            a.pagination-link.is-current @click='jumpRemixPage(1, $event)' 1
+          li
+            a.pagination-link aria-label=("Goto page 2") @click='jumpRemixPage(2, $event)'  2
+          li
+            a.pagination-link aria-label=("Goto page 3") @click='jumpRemixPage(3, $event)'  3
 
   .columns(v-if="currentTab === 'charge'")
     .column.is-12

--- a/nova/app/views/dashboard/show.html.slim
+++ b/nova/app/views/dashboard/show.html.slim
@@ -71,16 +71,10 @@
               .buttons.is-right
                 button.button.is-small(:disabled="amount < remit.amount" @click='accept(remit.id, $event)') Accept
                 button.button.is-small(@click='reject(remit.id, $event)') Reject
-      nav.pagination aria-label="pagination" role="navigation"
-        a.pagination-previous @click='changeRemixPage(-1, $event)' Previous
-        a.pagination-next @click='changeRemixPage(1, $event)' Next page
-        ul.pagination-list
+      nav.pagination
+        ul.pagination-list(v-for="(item, index) in new Array(maxPage)")
           li
-            a.pagination-link.is-current @click='jumpRemixPage(1, $event)' 1
-          li
-            a.pagination-link aria-label=("Goto page 2") @click='jumpRemixPage(2, $event)'  2
-          li
-            a.pagination-link aria-label=("Goto page 3") @click='jumpRemixPage(3, $event)'  3
+            a.pagination-link aria-label=("Goto page {index}") @click='jumpRemixPage(index + 1, $event)'  {{index + 1}}
 
   .columns(v-if="currentTab === 'charge'")
     .column.is-12

--- a/nova/spec/controllers/api/remit_requests_controller_spec.rb
+++ b/nova/spec/controllers/api/remit_requests_controller_spec.rb
@@ -8,16 +8,32 @@ RSpec.describe Api::RemitRequestsController, type: :controller do
   let(:remit_request) { create(:remit_request, target: user) }
 
   describe 'GET #index' do
-    subject { get :index }
+    context 'without page params' do
+      subject { get :index }
 
-    context 'without logged in' do
-      it { is_expected.to have_http_status(:unauthorized) }
+      context 'without logged in' do
+        it { is_expected.to have_http_status(:unauthorized) }
+      end
+
+      context 'with logged in' do
+        before { login!(user) }
+
+        it { is_expected.to have_http_status(:ok) }
+      end
     end
 
-    context 'with logged in' do
-      before { login!(user) }
+    context 'with page params' do
+      subject { get :index, params: { pages: 1 } }
 
-      it { is_expected.to have_http_status(:ok) }
+      context 'without logged in' do
+        it { is_expected.to have_http_status(:unauthorized) }
+      end
+
+      context 'with logged in' do
+        before { login!(user) }
+
+        it { is_expected.to have_http_status(:ok) }
+      end
     end
   end
 


### PR DESCRIPTION
[TODO]
- kaminariを使ったAPI
- ページネーションの作成

次のページへがないので、次のページへ行かないの処理を省いた
<img width="585" alt="2018-05-09 13 51 11" src="https://user-images.githubusercontent.com/8898432/39796211-2631f594-5390-11e8-87eb-0056de82fce8.png">

デフォルト50件だったのを10件ずつ表示するようにしました。

before API
```
[ {remit_requests1}, 
{remit_requests2}, 
{remit_requests3},
...
{remit_requests50}, ]
```

after API
```
{ 
maxPage: xx,
remit_requests: [ {remit_requests1}, 
{remit_requests2}, 
{remit_requests3},
...
{remit_requests10}, ]
}
```
