### PR TITLE
disable email setting

### DIFF
--- a/nova/app/views/dashboard/_setting.html.slim
+++ b/nova/app/views/dashboard/_setting.html.slim
@@ -10,7 +10,7 @@
       .field
         label.label E-Mail
         .control
-          input.input(type="email" v-model="user.email")
+          input.input(type="email" v-model="user.email" disabled="disabled")
       .field
         label.label Password
         .control

--- a/nova/app/views/users/new.html.slim
+++ b/nova/app/views/users/new.html.slim
@@ -5,7 +5,7 @@
     .control
       = f.text_field :nickname, class: 'input'
   .field
-    = f.label :email
+    = f.label 'Email (後から変更することはできません)'
     .control
       = f.email_field :email, class: 'input'
   .field


### PR DESCRIPTION
reqmit_requestをする際emailでタグ付けしているため、emailの変更をできないように変更
https://github.com/4geru/2018-newbies/blob/85364cd4d0cb546a1b4bc9e48a49597c26a3de26/nova/app/controllers/api/remit_requests_controller.rb#L12-L14

emailのuniqをつけて上書き変更できないようにしないとダメ