### PR TITLE
不要なテーブルカラムの削除

### DIFF
--- a/nova/db/migrate/20180515014229_remove_colum_to_users.rb
+++ b/nova/db/migrate/20180515014229_remove_colum_to_users.rb
@@ -1,0 +1,6 @@
+class RemoveColumToUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :staff, :boolean
+    remove_column :users, :remember_digest, :string
+  end
+end

--- a/nova/db/schema.rb
+++ b/nova/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_14_061717) do
+ActiveRecord::Schema.define(version: 2018_05_15_014229) do
 
   create_table "charges", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -47,14 +47,12 @@ ActiveRecord::Schema.define(version: 2018_05_14_061717) do
     t.string "nickname", null: false
     t.string "email", null: false
     t.string "stripe_id"
-    t.boolean "staff", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "activation_digest"
     t.boolean "activated", default: false
     t.datetime "activated_at"
     t.string "password_digest"
-    t.string "remember_digest"
     t.string "reset_digest"
     t.datetime "reset_sent_at"
     t.integer "amount", default: 0


### PR DESCRIPTION
`staff`と`remembre_digest`がnova内で使用されていないため、削除しようという判断になった。