### PR TITLE
limit remit requests api response

### DIFF
--- a/nova/app/controllers/api/remit_requests_controller.rb
+++ b/nova/app/controllers/api/remit_requests_controller.rb
@@ -10,7 +10,11 @@ class Api::RemitRequestsController < Api::ApplicationController
     pages = [remit_requests_count, 1].max / page_limit + 
       ( remit_requests_count % page_limit ? 0 : 1)
 
-    render json:{max_pages: pages, remit_requests: @remit_requests.as_json(include: [:user, :target] ).to_a}
+    render json:{max_pages: pages, remit_requests:
+      @remit_requests.as_json(include: {
+        user: { only: :email },
+        target: { only: :email }
+      }, only: [:amount, :status] ).to_a}
   end
 
   def create

--- a/nova/spec/controllers/api/remit_requests_controller_spec.rb
+++ b/nova/spec/controllers/api/remit_requests_controller_spec.rb
@@ -35,6 +35,54 @@ RSpec.describe Api::RemitRequestsController, type: :controller do
         it { is_expected.to have_http_status(:ok) }
       end
     end
+
+    context 'check response' do
+      before do 
+        login!(user)
+        create(:remit_request, target: user)
+        get :index
+        @json = JSON.parse(response.body)
+      end
+
+      context 'response' do
+        it 'include max_pages' do expect(@json.include?("max_pages")).to eq true end
+        it 'include remit_requests' do expect(@json.include?("remit_requests")).to eq true end
+        context 'remit_request' do
+          before do @remit_request = @json["remit_requests"].first end
+          it 'include remit_request.status' do expect(@remit_request.include?("status")).to eq true end
+          it 'include remit_request.amount' do expect(@remit_request.include?("amount")).to eq true end
+
+          it 'not include remit_request.id' do expect(@remit_request.include?("id")).to eq false end
+          it 'not include remit_request.user_id' do expect(@remit_request.include?("user_id")).to eq false end
+          it 'not include remit_request.target_id' do expect(@remit_request.include?("target_id")).to eq false end
+
+          context 'user' do
+            it 'include user.email' do expect(@remit_request["user"].include?("email")).to eq true end
+
+            it 'include user.id' do expect(@remit_request["user"].include?("id")).to eq false end
+            it 'not include user.nicgkname' do expect(@remit_request["user"].include?("nickname")).to eq false end
+            it 'not include user.stripe_id' do expect(@remit_request["user"].include?("stripe_id")).to eq false end
+            it 'not include user.activated' do expect(@remit_request["user"].include?("activated")).to eq false end
+            it 'not include user.password_digest' do expect(@remit_request["user"].include?("password_digest")).to eq false end
+            it 'not include user.activation_digest' do expect(@remit_request["user"].include?("activation_digest")).to eq false end
+            it 'not include user.reset_digest' do expect(@remit_request["user"].include?("reset_digest")).to eq false end
+            it 'not include user.amount' do expect(@remit_request["user"].include?("amount")).to eq false end
+          end
+
+          context 'target' do
+            it 'include target.email' do expect(@remit_request["target"].include?("email")).to eq true end
+            it 'include target.id' do expect(@remit_request["target"].include?("id")).to eq false end
+            it 'not include target.nickname' do expect(@remit_request["target"].include?("nickname")).to eq false end
+            it 'not include target.stripe_id' do expect(@remit_request["target"].include?("stripe_id")).to eq false end
+            it 'not include target.activated' do expect(@remit_request["target"].include?("activated")).to eq false end
+            it 'not include target.password_digest' do expect(@remit_request["target"].include?("password_digest")).to eq false end
+            it 'not include target.activation_digest' do expect(@remit_request["target"].include?("activation_digest")).to eq false end
+            it 'not include target.reset_digest' do expect(@remit_request["target"].include?("reset_digest")).to eq false end
+            it 'not include target.amount' do expect(@remit_request["target"].include?("amount")).to eq false end
+          end
+        end
+      end
+    end
   end
 
   describe 'POST #create' do


### PR DESCRIPTION
remit request apiのレスポンスで必要最低限の情報だけを返すようにしました。

```
{"max_pages":4,"
remit_requests":[
  {"amount":100,"status":"accepted","user":{"email":"geru@gmail.com"},"target":{"email":"hoge@gmail.com"}},
  {"amount":200,"status":"canceled","user":{"email":"hoge@gmail.com"},"target":{"email":"geru@gmail.com"}},
...]}
```