### PR TITLE
limit charge api response

### DIFF
--- a/nova/app/controllers/api/charges_controller.rb
+++ b/nova/app/controllers/api/charges_controller.rb
@@ -4,7 +4,7 @@ class Api::ChargesController < Api::ApplicationController
   def index
     @charges = current_user.charges.order(id: :desc).limit(50)
 
-    render json: { charges: @charges }
+    render json: { charges: @charges.as_json(only: [:amount, :created_at, :accepted_at]) }
   end
 
   def create

--- a/nova/spec/controllers/api/charges_controller_spec.rb
+++ b/nova/spec/controllers/api/charges_controller_spec.rb
@@ -17,6 +17,25 @@ RSpec.describe Api::ChargesController, type: :controller do
 
       it { is_expected.to have_http_status(:ok) }
     end
+
+
+    context 'check response' do
+      before do 
+        login!(user)
+        create(:charge, {user_id: user.id})
+        get :index
+        @charge = JSON.parse(response.body)["charges"][0]
+      end
+
+      it 'include amount' do expect(@charge.include?("amount")).to eq true end
+      it 'include created_at' do expect(@charge.include?("created_at")).to eq true end
+      #[TODO] accepted_at -> statusに変更する予定
+      xit 'include accepted_at' do expect(@charge.include?("accepted_at")).to eq true end
+
+      it 'not include id' do expect(@charge.include?("id")).to eq false end
+      it 'not include user_id' do expect(@charge.include?("user_id")).to eq false end
+
+    end
   end
 
   describe 'POST #create' do


### PR DESCRIPTION
chargesを必要最低限にした
```
{"charges":[
{"amount":50,"created_at":"2018-05-15T10:59:02.000+09:00","accepted_at":null},
{"amount":50,"created_at":"2018-05-15T10:58:56.000+09:00","accepted_at":null},
...]}
```